### PR TITLE
Add Dependabot configuration for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,15 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    commit-message:
+      prefix: "deps(python)"
+    schedule:
+      interval: "monthly"
+    target-branch: "main"
+    groups:
+      python:
+        patterns:
+          - "*"


### PR DESCRIPTION
# Pull Request

## Description

This change adds Python dependency management to the existing Dependabot configuration. The new configuration:

- Sets up a monthly check for Python package updates
- Targets the main branch for these updates
- Groups all Python dependencies together
- Uses the prefix "deps(python)" for commit messages related to Python dependency updates

This enhancement will help keep the project's Python dependencies up-to-date automatically, improving security and ensuring compatibility with the latest package versions.