### PR TITLE
Add logging to Mailinator email screenshot script

### DIFF
--- a/screenshot_mailinator_email.py
+++ b/screenshot_mailinator_email.py
@@ -12,12 +12,14 @@ def screenshot_mailinator_email() -> None:
             wait_until="load",
         )
         page.wait_for_timeout(2000)
+        print("Loading email pane")
         page.evaluate(
             "document.getElementById('email_pane').setAttribute('style', 'height: 500%; width: 100%;');"
         )
-        page.locator("#email_pane").screenshot(
-            path=f"{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}_email.png"
-        )
+        print("Enlarging email pane")
+        file_name = f"{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}_email.png"
+        page.locator("#email_pane").screenshot(path=file_name)
+        print(f"Saved screenshot to {file_name}")
         browser.close()
 
 


### PR DESCRIPTION
# Pull Request

## Description

This change enhances the `screenshot_mailinator_email` function by adding print statements to provide progress updates during execution. It also improves the screenshot file naming process by creating a separate variable for the file name, which is then used in both the screenshot capture and a new print statement confirming the save location.

The modifications include:
- Adding a print statement to indicate when the email pane is loading
- Adding a print statement to show when the email pane is being enlarged
- Creating a separate `file_name` variable for the screenshot
- Adding a print statement to confirm the location where the screenshot was saved

These changes improve the function's observability and make it easier to track its progress and output.